### PR TITLE
Fix Matrix URI

### DIFF
--- a/volunteers/templates/500.html
+++ b/volunteers/templates/500.html
@@ -12,7 +12,7 @@
         <link href='https://fonts.googleapis.com/css?family=Droid+Sans:regular,bold' rel='stylesheet' type='text/css' />
     </head>
   <body>
-    <div id="container">	
+    <div id="container">
         <div id="content-container">
             <h1>Site crashed</h1>
 

--- a/volunteers/templates/static/faq.html
+++ b/volunteers/templates/static/faq.html
@@ -63,7 +63,7 @@
 
     <ul class="faq">
         <li>Until the Friday before FOSDEM and starting the Monday after FOSDEM, <a href="https://lists.fosdem.org/listinfo/volunteers">the volunteers mailing list</a> will be primarily used.</li>
-	<li>Shortly before, during and after FOSDEM, we primarily use real time chat: <a href='https://chat.fosdem.org/#/room/#fosdem-volunteers:matrix.org'>matrix</a> or <a href="https://webchat.freenode.net?channels=fosdem-volunteers">irc</a>, channel #fosdem-volunteers..</li>
+        <li>Shortly before, during and after FOSDEM, we primarily use real time chat: <a href='https://chat.fosdem.org/#/room/#fosdem-volunteers:matrix.org'>matrix</a> or <a href="https://webchat.freenode.net?channels=fosdem-volunteers">irc</a>, channel #fosdem-volunteers..</li>
         <li>Need direct contact with the volunteers admins? Send an e-mail to <a href="mailto:volunteer-admin@lists.fosdem.org">volunteer-admin@lists.fosdem.org</a></li>
         <li>Urgent? Contact the volunteer admin(s) via +32 27 88 74 72. English should be used by default on the phone.</li>
         <li>Very urgent? Directly contact a FOSDEM staff member.</li>

--- a/volunteers/templates/static/promo.html
+++ b/volunteers/templates/static/promo.html
@@ -35,7 +35,7 @@
     <li><h3>Chat</h3>
 	    <p>Real time chat is bridged between matrix and irc:
 	       <ul>
-   	         <li><a href='matrix://#fosdem-volunteers:matrix.org'>#fosdem-volunteers</a> on matrix (<a href='https://chat.fosdem.org/#/room/#fosdem-volunteers:matrix.org'>webchat</a>)</li>
+   	         <li><a href="matrix:r/fosdem-volunteers:matrix.org">#fosdem-volunteers:matrix.org</a> on matrix (<a href="https://chat.fosdem.org/#/room/#fosdem-volunteers:matrix.org">webchat</a>)</li>
             <li><a href="irc://irc.libera.chat/fosdem-volunteers">#fosdem-volunteers</a> (<a href="https://web.libera.chat/#fosdem-volunteers">webchat</a>) on <a href="https://irc.libera.chat/">libera chat</a></li>
 	       </ul>
 	    </p>

--- a/volunteers/templates/static/promo.html
+++ b/volunteers/templates/static/promo.html
@@ -28,26 +28,26 @@
 
 <ul class="features">
     <li><h3>Mailing List</h3>
-			<p>You can subscribe to receive updates from the <a href="https://lists.fosdem.org/listinfo/volunteers">mailing list</a></p>
-			<p>You can post a message to all the members, send email to <a href="mailto:volunteers@lists.fosdem.org">volunteers@lists.fosdem.org</a></p>
+        <p>You can subscribe to receive updates from the <a href="https://lists.fosdem.org/listinfo/volunteers">mailing list</a></p>
+        <p>You can post a message to all the members, send email to <a href="mailto:volunteers@lists.fosdem.org">volunteers@lists.fosdem.org</a></p>
     </li>
 
     <li><h3>Chat</h3>
-	    <p>Real time chat is bridged between matrix and irc:
-	       <ul>
-   	         <li><a href="matrix:r/fosdem-volunteers:matrix.org">#fosdem-volunteers:matrix.org</a> on matrix (<a href="https://chat.fosdem.org/#/room/#fosdem-volunteers:matrix.org">webchat</a>)</li>
-            <li><a href="irc://irc.libera.chat/fosdem-volunteers">#fosdem-volunteers</a> (<a href="https://web.libera.chat/#fosdem-volunteers">webchat</a>) on <a href="https://irc.libera.chat/">libera chat</a></li>
-	       </ul>
-	    </p>
+        <p>Real time chat is bridged between matrix and irc:
+            <ul>
+                <li><a href="matrix:r/fosdem-volunteers:matrix.org">#fosdem-volunteers:matrix.org</a> on matrix (<a href="https://chat.fosdem.org/#/room/#fosdem-volunteers:matrix.org">webchat</a>)</li>
+                <li><a href="irc://irc.libera.chat/fosdem-volunteers">#fosdem-volunteers</a> (<a href="https://web.libera.chat/#fosdem-volunteers">webchat</a>) on <a href="https://irc.libera.chat/">libera chat</a></li>
+            </ul>
+        </p>
     </li>
 
     <li><h3>Real People</h3>
         <p><strong>Pieter De Praetere</strong></p>
-            <p><a href="mailto:pieter@fosdem.org">pieter@fosdem.org</a></p>
+        <p><a href="mailto:pieter@fosdem.org">pieter@fosdem.org</a></p>
         <p><strong>Sebastian Schauenburg</strong></p>
-		    <p><a href="mailto:sebastian@fosdem.org">sebastian@fosdem.org</a></p>
+        <p><a href="mailto:sebastian@fosdem.org">sebastian@fosdem.org</a></p>
         <p><strong>Kristian Schuhmacher</strong></p>
-		    <p><a href="mailto:kristian@fosdem.org">kristian@fosdem.org</a></p>
+        <p><a href="mailto:kristian@fosdem.org">kristian@fosdem.org</a></p>
     </li>
 </ul>
 {% endblock %}


### PR DESCRIPTION
The Matrix URI scheme has been standardized.

BTW my homeserver (halogen.city) is banned, which I believe to be because the ban list is inherited from matrix.org HQ room.  AFAICT few years ago there was a spammer using an account on the homeserver to spam offensive stuff (that person is still alive and spamming the homeserver's lobby but using kiwifarm accounts instead because halogen city registration is no longer as laxxed, poor admin has to ban those new KF accounts every other day).

My point is that I don't think the prejudice towards halogen city is any longer justified and I'd love to see the ban lifted.