### PR TITLE
Update readme and example settings so the dev setup instructions work

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ After cloning the repo do these steps:
    eg: `virtualenv -p /usr/bin/python3 ./venv`
    and activate this environment whenever working on the project (all other steps assume this)
    ```
-   ./venv/bin/activate
+   source ./venv/bin/activate
    ```
 
 2) Install all dependencies in the environment:
    ```
-   pip install -r requirements.txt
+   pip install -r requirements-dev.txt
    ```
 
 3) create a `volunteer_mgmt/localsettings.py` file

--- a/utils/setup-file-system.sh
+++ b/utils/setup-file-system.sh
@@ -2,7 +2,7 @@
 set -o errexit
 set -o nounset
 
-mkdir -p logs tool/media/mugshots
+mkdir -p tool/media/mugshots
 sqlite3 volunteers.db
 sqlite3 penta.db
 

--- a/utils/setup-server.sh
+++ b/utils/setup-server.sh
@@ -2,12 +2,7 @@
 set -o errexit
 set -o nounset
 
-sed "\
-        s/backends.postgresql_psycopg2/backends.sqlite3/; \
-        s/'NAME': '\([a-z]\+\)'/'NAME': '\1.db'/; \
-    " \
-    volunteer_mgmt/localsettings_example.py \
-    > volunteer_mgmt/localsettings.py
+cp volunteer_mgmt/localsettings_example.py volunteer_mgmt/localsettings.py
 
 . venv/bin/activate
 ./manage.py migrate

--- a/volunteer_mgmt/localsettings_example.py
+++ b/volunteer_mgmt/localsettings_example.py
@@ -16,22 +16,27 @@ else:
     DATABASES = {
         'default': {
             # 'django.db.backends.' +  'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
-            'ENGINE': 'django.db.backends.postgresql_psycopg2',
-            # Or path to database file if using sqlite3.
-            'NAME': 'volunteers',
-            'USER': 'volunteers',
-            'PASSWORD': 'volunteers',
-            'HOST': '127.0.0.1'
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': 'volunteers.db',
+            # Replace above with below for a local postgres DB (which you'll need to supply)
+            # 'ENGINE': 'django.db.backends.postgresql_psycopg2',
+            # 'NAME': 'volunteers',
+            # 'USER': 'volunteers',
+            # 'PASSWORD': 'volunteers',
+            # 'HOST': '127.0.0.1'
             # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
             # Set to empty string for default.
             # 'PORT': '5432',
         },
         'pentabarf': {
-            'ENGINE': 'django.db.backends.postgresql_psycopg2',
-            'NAME': 'penta',
-            'USER': 'volunteers',
-            'PASSWORD': 'volunteers',
-            'HOST': '127.0.0.1'
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': 'penta.db',
+            # Replace above with below for a local postgres DB (which you'll need to supply)
+            # 'ENGINE': 'django.db.backends.postgresql_psycopg2',
+            # 'NAME': 'penta',
+            # 'USER': 'volunteers',
+            # 'PASSWORD': 'volunteers',
+            # 'HOST': '127.0.0.1'
         }
     }
 


### PR DESCRIPTION
Some small `README.md` tweaks and updated the settings example to use a sqlite3 db as promised by the readme. Updated scripts that depend on the localsettings_example.py contents to reflect the change and kept the `logs` dir with a .gitkeep instead of manually creating it.