### PR TITLE
fix: Random characters on page

### DIFF
--- a/volunteers/templates/volunteers/tasks.html
+++ b/volunteers/templates/volunteers/tasks.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 
-{#{% if user.is_authenticated and not user_in_penta %}
+{% if user.is_authenticated and not user_in_penta %}
     <p class="faq">
     <h3>Register in pentabarf!</h3>
     Please register an account in <a href="https://penta.fosdem.org/submission">pentabarf</a> and add it to <a href="/volunteers/{{ user.username }}/edit/">your details</a> to enable hosting talks.
@@ -14,7 +14,7 @@
     </p>
 
 {% endif %}
-#}
+
 {% if user.is_authenticated %}<a class="larger-font" href="{% url 'task_list_detailed' user.username %}" title="View schedule">View your schedule</a>{% endif %}
 
 <form class="task_list" action="{% url 'task_list' %}" method="post">{% csrf_token %}


### PR DESCRIPTION
After connecting Penta, there are random characters left on the page as shown below. This PR removes them.

I haven't got much experience with the setup here and thought this could be a quick fix, please let me know if there is any oversight and the `{#` are needed

<img width="1029" alt="Screenshot 2023-02-01 at 19 08 42" src="https://user-images.githubusercontent.com/29015545/216139664-9990b65d-83fa-419c-b95d-eaf5ca022806.png">