### PR TITLE
Updates for 2024

### DIFF
--- a/volunteers/templates/static/promo.html
+++ b/volunteers/templates/static/promo.html
@@ -17,7 +17,7 @@
     </li>
 
     <li><h3>Location</h3>
-        <p>FOSDEM 2023 will be returning the the ULB in Brussels, Belgium, while continuing to offer an online presence.</p>
+        <p>FOSDEM 2024 will be returning the the ULB in Brussels, Belgium, while continuing to offer an online presence.</p>
     </li>
 
     <li><h3>Volunteering</h3>

--- a/volunteers/templates/static/promo.html
+++ b/volunteers/templates/static/promo.html
@@ -36,7 +36,6 @@
 	    <p>Real time chat is bridged between matrix and irc:
 	       <ul>
    	         <li><a href='https://matrix.to/#/#volunteers:fosdem.org'>#fosdem-volunteers</a> on matrix (<a href='https://chat.fosdem.org/#/room/#volunteers:fosdem.org'>webchat</a>)</li>
-            <li><a href="irc://irc.libera.chat/fosdem-volunteers">#fosdem-volunteers</a> (<a href="https://web.libera.chat/#fosdem-volunteers">webchat</a>) on <a href="https://irc.libera.chat/">libera chat</a></li>
 	       </ul>
 	    </p>
     </li>

--- a/volunteers/templates/static/promo.html
+++ b/volunteers/templates/static/promo.html
@@ -42,9 +42,11 @@
 
     <li><h3>Real People</h3>
         <p><strong>Pieter De Praetere</strong></p>
-            <p><a href="mailto:pieter@fosdem.org">pieter@fosdem.org</a></p>
+        <p><a href="mailto:pieter@fosdem.org">Send Pieter an email</a></p>
         <p><strong>Kristian Schuhmacher</strong></p>
-		    <p><a href="mailto:kristian@fosdem.org">kristian@fosdem.org</a></p>
+		<p><a href="mailto:kristian@fosdem.org">Send Kristian an email</a></p>
+        <p><strong>Dan Clark</strong></p>
+		<p><a href="mailto:dan@fosdem.org">Send Dan an email</a></p>
     </li>
 </ul>
 {% endblock %}


### PR DESCRIPTION
Changed homepage date to 2024, removed libre chat because of broken bridge, and added Dan as volunteer coordinator.

Closes #63, closes #64