### PR TITLE
Fix bug where old tasks could silently be moved to the current edition

### DIFF
--- a/volunteers/models.py
+++ b/volunteers/models.py
@@ -218,7 +218,7 @@ class Talk(models.Model):
     @classmethod
     def penta_create_or_update(cls, xml, edition, day_date):
         event_id = xml.get('id')
-        talks = cls.objects.filter(ext_id=event_id)
+        talks = cls.objects.filter(ext_id=event_id, edition=edition)
         if len(talks):
             talk = talks[0]
         else:
@@ -383,7 +383,7 @@ class Task(models.Model):
     #        ideal, min, max
     @classmethod
     def create_or_update_from_talk(cls, edition, talk, task_type, volunteers):
-        tasks = cls.objects.filter(talk=talk, template__name=task_type)
+        tasks = cls.objects.filter(talk=talk, template__name=task_type, edition=edition)
         templates = TaskTemplate.objects.filter(name=task_type)
         if len(templates):
             template = templates[0]


### PR DESCRIPTION
Fixes #96. This became and issue when we transitioned from penta to pretalx, because talk event IDs which were unique, are now being reused as pretalx has no knowledge of the past editions in penta. The tool ended up pulling volunteering tasks from old editions if there was a talk ID collision.
This fix now assumes that talk IDs are unique within each edition, which is true, and also makes the same fix to task IDs to avoid a possible issue caused by talks with the same name.

Note: This will not fix talks/tasks which have already been pulled from previous editions.