### PR TITLE
clarify password forget notice

### DIFF
--- a/volunteers/templates/registration/password_reset_done.html
+++ b/volunteers/templates/registration/password_reset_done.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block title %}{% trans "Password reset email sent" %}{% endblock %}
-{% block content_title %}<h2 class="huge-font">{% trans "Password has been reset" %}</h2>{% endblock %}
+{% block content_title %}<h2 class="huge-font">{% trans "If an account exists with this address, you will receive a password-reset email within the next few minutes." %}</h2>{% endblock %}
 
 {% block content %}
 <p class="huge-font">{% trans "Your password has been reset." %}</p>


### PR DESCRIPTION
Technically we do (the correct thing) where we dont tell the user if the emailadres isn't actually in our system. But that means we should clarify if an account does not  exist, they won't receive an email (as obvious that might seemt to us)